### PR TITLE
Fix for devices list

### DIFF
--- a/FHEM/89_AndroidDBHost.pm
+++ b/FHEM/89_AndroidDBHost.pm
@@ -482,7 +482,8 @@ sub GetDeviceList ($)
 	return undef if ($rc == 0);	
 
 	my %devState = ();
-	my @devices = $result =~ /([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[0-9]+\s+[a-zA-Z0-9]+)/g;
+	my @devices = $result =~ /([a-zA-Z0-9]+:[0-9]+\s+[a-zA-Z0-9]+)|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[0-9]+\s+[a-zA-Z0-9]+)/g;
+	@devices = grep { $_ ne '' } @devices;
 	foreach my $d (@devices) {
 		my ($address, $state) = split /\s+/, $d;
 		$devState{$address} = $state // 'disconnected';


### PR DESCRIPTION
With this fix, also devices which have been connected to by hostname will appear in the device list. Furthermore, the array is cleaned after filling it with devices, as it always contained an empty item which is shown as disconnected in the devices list. Please also see https://forum.fhem.de/index.php?msg=1313387, where I already tried to propose it.