### PR TITLE
Fix warning for possibly uninitialized value

### DIFF
--- a/FHEM/89_AndroidDBHost.pm
+++ b/FHEM/89_AndroidDBHost.pm
@@ -483,7 +483,7 @@ sub GetDeviceList ($)
 
 	my %devState = ();
 	my @devices = $result =~ /([a-zA-Z0-9]+:[0-9]+\s+[a-zA-Z0-9]+)|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[0-9]+\s+[a-zA-Z0-9]+)/g;
-	@devices = grep { $_ ne '' } @devices;
+	@devices = grep { defined $_ && $_ ne '' } @devices;
 	foreach my $d (@devices) {
 		my ($address, $state) = split /\s+/, $d;
 		$devState{$address} = $state // 'disconnected';


### PR DESCRIPTION
With this small addition, there is no more warning during startup of FHEM:
```
PERL WARNING: Use of uninitialized value $_ in string ne at /usr/share/fhem/FHEM/89_AndroidDBHost.pm line 486
```